### PR TITLE
fix: publish src/ directory for ES Modules compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "prepublish": "npm run build && npm run lint"
   },
   "files": [
-    "lib"
+    "lib",
+    "src"
   ],
   "keywords": [
     "animate",


### PR DESCRIPTION
## Motivation

- Tried using spring-animator inside of a `Vite` project, ran into an error. Bundlers that were using the `umd` entrypoint are unaffected.
- Without this adjustment, the package can't be imported as an ES Module (as specified in the package.json's `module` field), since the src/ folder doesn't exist. Importing the UMD version may contribute to a longer hot reload time.

## Testing

- Modified my local `node_modules/` with a copy of `src/index.js`, everything worked.